### PR TITLE
add await to validate user password

### DIFF
--- a/src/controllers/users.js
+++ b/src/controllers/users.js
@@ -24,7 +24,7 @@ const login = async (req, res) => {
     res.status(401).json({ error: 'invalid username or password' });
     return;
   }
-  if (!user.validatePassword(password)) {
+  if (!(await user.validatePassword(password))) {
     res.status(401).json({ error: 'invalid username or password' });
     return;
   }


### PR DESCRIPTION
**Why**: the user password validation function does not work as expected.
**What**: with a wrong password, it will still return status 200 and the token. 
**how**: add `await` before the password validating function so it works as expected.

<img width="1081" alt="image" src="https://user-images.githubusercontent.com/63524682/212249840-f1559850-8b7d-45fa-a4c6-89a730ebe04d.png">

test on localhost3000 with postman by Trent